### PR TITLE
Two simple fixes

### DIFF
--- a/mamba/test/test_config.py
+++ b/mamba/test/test_config.py
@@ -61,6 +61,12 @@ class DatabaseTest(unittest.TestCase):
         self.assertTrue(config.Database().loaded)
         self.assertEqual(config.Database().min_threads, 5)
 
+    def test_database_write(self):
+        config.Database.write({})
+        config.Database('./config/database.json')
+        self.assertTrue(config.Database().loaded)
+
+
 
 class ApplicationTest(unittest.TestCase):
     """Fallback functionallity already tested on Database Tests

--- a/mamba/utils/config.py
+++ b/mamba/utils/config.py
@@ -162,7 +162,7 @@ class Database(BaseConfig):
             '{}/config/database.json'.format(filepath.abspath('.'))
         )
 
-        if not config_file.exists():
+        if not config_file.parent().exists():
             config_file.parent().createDirectory()
 
         config_file.open('w').write(json.dumps(options, indent=4))


### PR DESCRIPTION
Hi, Mister.

Well, here are two really small fixes.

One fixes that issue when trying to create a config file with no config folder.
Another fixes a problem I found in the default configuration file, which contains 'sqlite:' as URI and it should be 'sqlite://' as per my understanding.

Regards.
