### PR TITLE
Added __mamba_schema__ support. When set to false, the table will not be...

### DIFF
--- a/mamba/application/model.py
+++ b/mamba/application/model.py
@@ -280,6 +280,11 @@ class Model(ModelProvider):
 
         return uri
 
+    def on_schema(self):
+        """Checks if Mamba should take care of this model.
+        """
+        return getattr(self, '__mamba_schema__', True)
+
     def get_adapter(self):
         """Get a valid adapter for this model
         """

--- a/mamba/enterprise/database.py
+++ b/mamba/enterprise/database.py
@@ -166,6 +166,8 @@ class Database(object):
         if full is False:
             sql.append('')
             for model in model_manager.get_models().values():
+                if not model.get('object').on_schema():
+                    continue
                 if self.backend == 'postgres':
                     references.append(model.get('object').dump_references())
 
@@ -173,6 +175,10 @@ class Database(object):
         else:
             for model in model_manager.get_models().values():
                 model_object = model.get('object')
+
+                if not model_object.on_schema():
+                    continue
+
                 sql.append('--')
                 sql.append('-- Table structure for table {}'.format(
                     model_object.__storm_table__
@@ -217,6 +223,7 @@ class Database(object):
         sql = [
             model.get('object').dump_table()
             for model in model_manager.get_models().values()
+            if model.get('object').on_schema() is True
         ]
 
         return '\n'.join(sql)

--- a/mamba/test/dummy_app/application/model/dummy_not_on_schema.py
+++ b/mamba/test/dummy_app/application/model/dummy_not_on_schema.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+# -*- mamba-file-type: mamba-model -*-
+# Copyright (c) 2012 - Oscar Campos <oscar.campos@member.fsf.org>
+
+"""
+.. model:: Dummy
+    :plarform: Linux
+    :synopsis: Dummy model for testing purposes
+
+.. modelauthor:: Oscar Campos <oscar.campos@member.fsf.org>
+"""
+
+from storm.locals import Int, Unicode
+
+from mamba.application import model
+
+
+class DummyNotOnSchemaModel(model.Model, model.ModelProvider):
+    """Dummy model for testing purposes
+    """
+
+    __storm_table__ = 'dummy_not_on_schema'
+    __mamba_schema__ = False
+
+    id = Int(primary=True, unsigned=True, auto_increment=True)
+    name = Unicode(size=64, allow_none=False)
+
+    def __init__(self, name=None):
+        super(DummyNotOnSchemaModel, self).__init__()
+
+        if name is not None:
+            self.name = unicode(name)

--- a/mamba/test/test_database.py
+++ b/mamba/test/test_database.py
@@ -152,6 +152,29 @@ class DatabaseTest(unittest.TestCase):
         self.flushLoggedErrors()
         self.database.store().reset()
 
+    def test_database_not_dump_mamba_schema_false(self):
+        mgr = self.get_commons_for_dump()
+
+        mgr.load('../mamba/test/dummy_app/application/model/dummy.py')
+        mgr.load('../mamba/test/dummy_app/application/model/stubing.py')
+        mgr.load(
+            '../mamba/test/dummy_app/application/model/dummy_not_on_schema.py'
+
+        )
+        sql = self.database.dump(mgr)
+        self.assertTrue('CREATE TABLE IF NOT EXISTS dummy (\n' in sql)
+        self.assertTrue('  name VARCHAR NOT NULL,\n' in sql)
+        self.assertTrue('  id INTEGER,\n' in sql)
+        self.assertTrue('  PRIMARY KEY(id)\n);\n\n' in sql)
+        self.assertTrue('CREATE TABLE IF NOT EXISTS stubing (\n' in sql)
+        self.assertTrue('  id INTEGER,\n' in sql)
+        self.assertTrue('  name VARCHAR NOT NULL,\n' in sql)
+        self.assertTrue('  PRIMARY KEY(id)\n);\n' in sql)
+        self.assertTrue('dummy_not_on_schema' not in sql)
+
+        self.flushLoggedErrors()
+        self.database.store().reset()
+
     def test_database_dump_data(self):
         config.Database('../mamba/test/dummy_app/config/database.json')
         mgr = self.get_commons_for_dump()
@@ -182,6 +205,21 @@ class DatabaseTest(unittest.TestCase):
         self.assertTrue('CREATE TABLE dummy (' in sql)
         self.assertTrue('CREATE TABLE stubing (' in sql)
 
+    def test_database_reset_mamba_schema_false(self):
+        mgr = self.get_commons_for_dump()
+
+        mgr.load('../mamba/test/dummy_app/application/model/dummy.py')
+        mgr.load('../mamba/test/dummy_app/application/model/stubing.py')
+        mgr.load(
+            '../mamba/test/dummy_app/application/model/dummy_not_on_schema.py'
+        )
+        sql = self.database.reset(mgr)
+        self.assertTrue('DROP TABLE IF EXISTS dummy;' in sql)
+        self.assertTrue('DROP TABLE IF EXISTS stubing;' in sql)
+        self.assertTrue('CREATE TABLE dummy (' in sql)
+        self.assertTrue('CREATE TABLE stubing (' in sql)
+        self.assertTrue('dummy_not_on_schema' not in sql)
+
     def test_database_reset_mysql(self):
         cfg = config.Database('../mamba/test/dummy_app/config/database.json')
         cfg.uri = cfg.uri.replace('sqlite:', 'mysql://a:b@c/d')
@@ -195,6 +233,23 @@ class DatabaseTest(unittest.TestCase):
         self.assertTrue('CREATE TABLE `dummy` (' in sql)
         self.assertTrue('CREATE TABLE `stubing` (' in sql)
 
+    def test_database_reset_mysql_mamba_schema_false(self):
+        cfg = config.Database('../mamba/test/dummy_app/config/database.json')
+        cfg.uri = cfg.uri.replace('sqlite:', 'mysql://a:b@c/d')
+        mgr = self.get_commons_for_dump()
+
+        mgr.load('../mamba/test/dummy_app/application/model/dummy.py')
+        mgr.load('../mamba/test/dummy_app/application/model/stubing.py')
+        mgr.load(
+            '../mamba/test/dummy_app/application/model/dummy_not_on_schema.py'
+        )
+        sql = self.database.reset(mgr)
+        self.assertTrue('DROP TABLE IF EXISTS `dummy`;' in sql)
+        self.assertTrue('DROP TABLE IF EXISTS `stubing`;' in sql)
+        self.assertTrue('CREATE TABLE `dummy` (' in sql)
+        self.assertTrue('CREATE TABLE `stubing` (' in sql)
+        self.assertTrue('dummy_not_on_schema' not in sql)
+
     def test_database_reset_postgres(self):
         cfg = config.Database('../mamba/test/dummy_app/config/database.json')
         cfg.uri = cfg.uri.replace('sqlite:', 'postgres://a:b@c/d')
@@ -207,6 +262,20 @@ class DatabaseTest(unittest.TestCase):
         self.assertTrue('DROP TABLE IF EXISTS stubing RESTRICT;' in sql)
         self.assertTrue('CREATE TABLE dummy (' in sql)
         self.assertTrue('CREATE TABLE stubing (' in sql)
+
+    def test_database_reset_postgres_mamba_schema_false(self):
+        cfg = config.Database('../mamba/test/dummy_app/config/database.json')
+        cfg.uri = cfg.uri.replace('sqlite:', 'postgres://a:b@c/d')
+        mgr = self.get_commons_for_dump()
+
+        mgr.load('../mamba/test/dummy_app/application/model/dummy.py')
+        mgr.load('../mamba/test/dummy_app/application/model/stubing.py')
+        sql = self.database.reset(mgr)
+        self.assertTrue('DROP TABLE IF EXISTS dummy RESTRICT;' in sql)
+        self.assertTrue('DROP TABLE IF EXISTS stubing RESTRICT;' in sql)
+        self.assertTrue('CREATE TABLE dummy (' in sql)
+        self.assertTrue('CREATE TABLE stubing (' in sql)
+        self.assertTrue('dummy_not_on_schema' not in sql)
 
 
 class NativeEnumTest(unittest.TestCase):

--- a/mamba/test/test_model.py
+++ b/mamba/test/test_model.py
@@ -712,8 +712,6 @@ class ModelTest(unittest.TestCase):
         adapter = self.get_adapter()
         self.assertEqual(adapter.drop_table(), 'DROP TABLE dummy')
 
-
-
     @common_config(engine='mysql:')
     def test_mysql_drop_table(self):
 
@@ -939,7 +937,7 @@ class ModelManagerTest(unittest.TestCase):
 
         self.assertNotEqual(dummy, dummy2)
 
-    def test_lenght(self):
+    def test_length(self):
         self.assertEqual(self.mgr.length(), 0)
         self.load_manager()
         self.assertEqual(self.mgr.length(), 1)
@@ -1070,6 +1068,7 @@ class DummyModelFive(Model):
         (DummyModelFour.id, DummyModelFour.second_id)
     )
 
+
 class DummyModelSix(Model):
     """Dummy Model for testing purposes"""
 
@@ -1079,6 +1078,7 @@ class DummyModelSix(Model):
     second_id = Int()
     third_id = Int()
     fourth_id = Int()
+
 
 class DummyModelEnum(Model):
     """Dummy Model for testing purposes"""


### PR DESCRIPTION
... used when Mamba uses its schema generator whether for creation, dumping or dropping.
