### PR TITLE
Added support for --noschema on command-line mamba-admin tool as per #20...

### DIFF
--- a/mamba/scripts/_model.py
+++ b/mamba/scripts/_model.py
@@ -41,6 +41,8 @@ class ModelOptions(usage.Options):
 
     optFlags = [
         ['dump', 'd', 'Dump the configuration to the standard output'],
+        ['noschema', 's',
+            'Set this if you don\'t want Mamba manaing this at schema-level'],
         ['noquestions', 'n',
             'When this option is set, mamba will NOT ask anything to the user '
             'that means ot will overwrite any other version of the model file '
@@ -191,9 +193,15 @@ class Model(object):
         else:
             classname = self.options.subOptions.opts['classname']
 
+        if self.options.subOptions.opts['noschema'] != 0:
+            class_properties = '__mamba_schema__ = False\n'
+        else:
+            class_properties = ''
+
         args = {
             'model_table': self.options.subOptions.opts['model_table'],
             'model_properties': self.model_properties,
+            'class_properties': class_properties,
             'year': datetime.datetime.now().year,
             'model_name': self.options.subOptions.opts['name'],
             'platforms': self.options.subOptions.opts['platforms'],
@@ -201,7 +209,7 @@ class Model(object):
             'author': self.options.subOptions.opts['author'],
             'author_email': self.options.subOptions.opts['email'],
             'synopsis': self.options.subOptions.opts['description'],
-            'model_class': classname
+            'model_class': classname,
         }
 
         return controller_template.safe_substitute(**args)

--- a/mamba/templates/model.tpl
+++ b/mamba/templates/model.tpl
@@ -10,7 +10,7 @@
 .. modelauthor:: ${author} <${author_email}>
 """
 
-# is better if you remove this star import and import just what you
+# it's better if you remove this star import and import just what you
 # really need from storm.properties, storm.references and storm.expr
 from storm.locals import *
 
@@ -23,5 +23,5 @@ class ${model_class}(model.Model):
     """
 
     __storm_table__ = '${model_table}'
-
+    ${class_properties}
     ${model_properties}


### PR DESCRIPTION
Hi, this is about issue #20.

Three observations:

1 - Not sure if 's' as abbreviated option was a wise choice.
2 - Not sure if the description of the option itself is good.
3 - I changed the model.tpl so as the distance between the class properties and the fields would always be one line.
