### PR TITLE
Fixed duplicated index name mentioned in #51.

### DIFF
--- a/mamba/enterprise/mysql.py
+++ b/mamba/enterprise/mysql.py
@@ -259,9 +259,11 @@ class MySQL(CommonSQL):
                 )
 
                 query = (
-                    'INDEX `{remote_table}_fk_ind` ({localkeys}), FOREIGN KEY '
-                    '({localkeys}) REFERENCES `{remote_table}`({remotekeys}) '
-                    'ON UPDATE {on_update} ON DELETE {on_delete}'.format(
+                    'INDEX `{field}_{remote_table}_fk_ind` ({localkeys}), '
+                    'FOREIGN KEY ({localkeys}) REFERENCES `{remote_table}` '
+                    '({remotekeys}) ON UPDATE {on_update} '
+                    'ON DELETE {on_delete}'.format(
+                        field=keys.get('local')[0].name,
                         remote_table=remote_table,
                         localkeys=localkeys,
                         remotekeys=remotekeys,

--- a/mamba/enterprise/postgres.py
+++ b/mamba/enterprise/postgres.py
@@ -180,9 +180,10 @@ class PostgreSQL(CommonSQL):
 
                 query = (
                     'ALTER TABLE {table} ADD '
-                    'CONSTRAINT {remote_table}_ind FOREIGN KEY ({localkeys}) '
-                    'REFERENCES {remote_table}({remotekeys}) '
+                    'CONSTRAINT {field}_{remote_table}_ind FOREIGN KEY '
+                    '({localkeys}) REFERENCES {remote_table}({remotekeys}) '
                     'ON UPDATE {on_update} ON DELETE {on_delete};\n'.format(
+                        field=keys.get('local')[0].name,
                         table=self.model.__storm_table__,
                         remote_table=remote_table,
                         localkeys=localkeys,


### PR DESCRIPTION
MySQL and Postgres now will not suffer from the duplicated index name problem. Local field is added on the name for clarity.
